### PR TITLE
Fix Concessionario property recursion

### DIFF
--- a/module2/excercise/14_concessionario_2/Concessionario.py
+++ b/module2/excercise/14_concessionario_2/Concessionario.py
@@ -1,23 +1,36 @@
-from typing import List
+from typing import List, Optional
 
 from Veicolo import Veicolo
 class Concessionario:
-    def __init__(self, nome : str, lista_auto : List[Veicolo]):
+    def __init__(self, nome: str, lista_auto: List[Veicolo]):
+        self._nome: Optional[str] = None
+        self._lista_auto: List[Veicolo] = []
         self.nome = nome
         self.lista_auto = lista_auto
 
     @property
-    def nome(self):
-        return self.nome
+    def nome(self) -> str:
+        return self._nome
 
     @nome.setter
-    def nome(self, nome : str):
-        self.nome = nome
+    def nome(self, nome: str) -> None:
+        if not isinstance(nome, str):
+            raise TypeError("Il nome del concessionario deve essere una stringa")
+        if not nome:
+            raise ValueError("Il nome del concessionario non può essere vuoto")
+        self._nome = nome
 
     @property
-    def lista_auto(self):
-        return self.lista_auto
+    def lista_auto(self) -> List[Veicolo]:
+        return list(self._lista_auto)
 
     @lista_auto.setter
-    def lista_auto(self, lista_auto : List[Veicolo]):
-        self.lista_auto = lista_auto
+    def lista_auto(self, lista_auto: List[Veicolo]) -> None:
+        if lista_auto is None:
+            raise TypeError("La lista delle auto non può essere None")
+        if not isinstance(lista_auto, list):
+            raise TypeError("La lista delle auto deve essere una lista")
+        for veicolo in lista_auto:
+            if not isinstance(veicolo, Veicolo):
+                raise TypeError("Tutti gli elementi devono essere istanze di Veicolo")
+        self._lista_auto = list(lista_auto)


### PR DESCRIPTION
## Summary
- switch the Concessionario properties to use private backing attributes
- add validation and list copying in the setters to prevent recursion and aliasing

## Testing
- python - <<'PY'
import sys
from pathlib import Path
sys.path.append(str(Path('module2/excercise/14_concessionario_2').resolve()))
from Concessionario import Concessionario
from Veicolo import Veicolo

v1 = Veicolo("Fiat", "Panda", 2020, 10000)
v2 = Veicolo("Ford", "Focus", 2018, 8000)
concessionario = Concessionario("AutoMax", [v1, v2])
print(concessionario.nome)
print(len(concessionario.lista_auto))
# modifica una copia restituita dal getter
nuova_lista = concessionario.lista_auto
nuova_lista.append(Veicolo("Toyota", "Yaris", 2021, 9000))
print(len(concessionario.lista_auto))
concessionario.lista_auto = nuova_lista
print(len(concessionario.lista_auto))
concessionario.nome = "SuperAuto"
print(concessionario.nome)
PY

------
https://chatgpt.com/codex/tasks/task_e_68e67ac3c8448320931e0120aa027e67